### PR TITLE
2023.Q1.2

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -24,7 +24,7 @@ plain '       `-+shdNNNNNNNNNNNNNNNdhs+-`'
 plain '             `.-:///////:-.`'
 
 pkgname=amdvlk-tkg
-pkgver=2023.Q1.1
+pkgver=2023.Q1.2
 pkgrel=1
 pkgdesc="AMD's standalone Vulkan driver"
 arch=(x86_64)
@@ -34,7 +34,7 @@ provides=('vulkan-driver' 'lib32-vulkan-driver' 'amdvlk' 'lib32-amdvlk')
 makedepends=('directx-shader-compiler' 'perl-xml-xpath' 'python' 'wayland' 'lib32-wayland' 'libxrandr' 'lib32-libxrandr' 'xorg-server-devel' 'cmake' 'ninja' 'git' 'glslang' 'ocaml-stdlib-shims')
 options=('!lto')
 source=("https://github.com/GPUOpen-Drivers/AMDVLK/archive/v-${pkgver}.tar.gz")
-sha256sums=('5511ccf9ff052808b8305aa46acd4a807fd7d95a7520d7d4a3fd8893f7937ffa')
+sha256sums=('b581ddea7928d3260b3ad917502678b6cb44d1f37c19d07ed04e536fbee6d5e0')
 
 # Workaround for chroot
 if [[ "$PATH" != *"/bin/vendor_perl"* ]];then


### PR DESCRIPTION
Hi,

I have upgraded AMDVLK to version 2023.Q1.2.
I still need the workaround for llvm-dialects to compile but work like a charm.

Thanks again for the merge of 2023.Q1.1